### PR TITLE
Offer to choose ACL policy and user registration

### DIFF
--- a/admin/delete.php
+++ b/admin/delete.php
@@ -81,7 +81,7 @@ class admin_plugin_farmer_delete extends DokuWiki_Admin_Plugin {
 
         $animals = $this->helper->getAllAnimals();
         array_unshift($animals, '');
-        $form->addDropdown('delanimal', $animals)->addClass('farmer_choosen_animals');
+        $form->addDropdown('delanimal', $animals)->addClass('farmer_chosen_animals');
         $form->addTextInput('confirm', $this->getLang('delete_confirm'));
         $form->addButton('delete', $this->getLang('delete'));
         $form->addFieldsetClose();

--- a/admin/new.php
+++ b/admin/new.php
@@ -38,7 +38,7 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
 
         $data = $this->validateAnimalData();
         if(!$data) return;
-        if($this->createNewAnimal($data['name'], $data['admin'], $data['pass'], $data['template'])) {
+        if($this->createNewAnimal($data['name'], $data['admin'], $data['pass'], $data['template'], $data['aclpolicy'], $data['allowreg'])) {
             $url = $this->helper->getAnimalURL($data['name']);
             $link = '<a href="' . $url . '">' . hsc($data['name']) . '</a>';
 
@@ -52,6 +52,7 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
      * Render HTML output, e.g. helpful text and a form
      */
     public function html() {
+        global $lang;
         $farmconfig = $this->helper->getConfig();
 
         $form = new \dokuwiki\Form\Form();
@@ -65,6 +66,19 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
         array_unshift($animals, '');
         $form->addFieldsetOpen($this->getLang('animal template'));
         $form->addDropdown('animaltemplate', $animals)->addClass('farmer_choosen_animals');
+        $form->addFieldsetClose();
+
+        $form->addFieldsetOpen($lang['i_policy'])->attr('id', 'aclPolicyFieldset');
+        $policyOptions = array('open' => $lang['i_pol0'],'public' => $lang['i_pol1'], 'closed' => $lang['i_pol2']);
+        $form->addDropdown('aclpolicy', $policyOptions)->addClass('acl_chosen');
+        if ($farmconfig['inherit']['main']) {
+            $form->addRadioButton('allowreg',$this->getLang('inherit user registration'))->val('inherit')->attr('checked', 'checked');
+            $form->addRadioButton('allowreg',$this->getLang('enable user registration'))->val('allow');
+            $form->addRadioButton('allowreg',$this->getLang('disable user registration'))->val('disable');
+        } else {
+            $form->addCheckbox('allowreg', $lang['i_allowreg'])->attr('checked', 'checked');
+        }
+
         $form->addFieldsetClose();
 
         $form->addFieldsetOpen($this->getLang('animal administrator'));
@@ -99,6 +113,8 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
         $adminsetup = $INPUT->str('adminsetup');
         $adminpass = $INPUT->filter('trim')->str('adminPassword');
         $template = $INPUT->filter('trim')->str('animaltemplate');
+        $aclpolicy = $INPUT->filter('trim')->str('aclpolicy');
+        $allowreg = $INPUT->str('allowreg');
 
         $errors = array();
 
@@ -116,6 +132,10 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
             $errors[] = $this->getLang('animalname_preexisting');
         }
 
+        if (!is_dir(DOKU_FARMDIR . $template) && !in_array($aclpolicy,array('open', 'public', 'closed'))) {
+            $errors[] = $this->getLang('aclpolicy missing/bad');
+        }
+
         if($errors) {
             foreach($errors as $error) {
                 msg($error, -1);
@@ -126,12 +146,17 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
         if(!is_dir(DOKU_FARMDIR . $template)) {
             $template = '';
         }
+        if ($template != '') {
+            $aclpolicy = '';
+        }
 
         return array(
             'name' => $animalname,
             'admin' => $adminsetup,
             'pass' => $adminpass,
-            'template' => $template
+            'template' => $template,
+            'aclpolicy' => $aclpolicy,
+            'allowreg' => $allowreg
         );
     }
 
@@ -142,9 +167,12 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
      * @param string $adminSetup newAdmin, currentAdmin or importUsers
      * @param string $adminPassword required if $adminSetup is newAdmin
      * @param string $template name of animal to copy
+     * @param $aclpolicy
+     * @param $userreg
      * @return bool true if successful
+     * @throws Exception
      */
-    protected function createNewAnimal($name, $adminSetup, $adminPassword, $template) {
+    protected function createNewAnimal($name, $adminSetup, $adminPassword, $template, $aclpolicy, $userreg) {
         $animaldir = DOKU_FARMDIR . $name;
 
         // copy basic template
@@ -211,6 +239,45 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
         }
         if($users) {
             $ok &= io_saveFile($animaldir . '/conf/users.auth.php', $users);
+        }
+
+        if ($aclpolicy != '') {
+            $aclfile = file($animaldir . '/conf/acl.auth.php');
+            array_pop($aclfile);
+            switch ($aclpolicy) {
+                case 'open':
+                    $aclfile[] = "* @ALL 8";
+                    break;
+                case 'public':
+                    $aclfile[] = "* @ALL 1";
+                    $aclfile[] = "* @user 8";
+                    break;
+                case 'closed':
+                    $aclfile[] = "* @ALL 0";
+                    $aclfile[] = "* @user 8";
+                    break;
+                default:
+                    throw new Exception('Undefined aclpolicy given');
+            }
+            $ok &= io_saveFile($animaldir . '/conf/acl.auth.php', join("\n", $aclfile));
+
+            global $conf;
+            switch ($userreg) {
+                case 'allow':
+                    $disableactions = join(',', array_diff(explode(',', $conf['disableactions']), array('register')));
+                    $ok &= io_saveFile($animaldir . '/conf/local.php', "\n" . '$conf[\'disableactions\'] = \''.$disableactions.'\';' . "\n", true);
+                    break;
+                case 'disable':
+                    $disableactions = join(',', array_merge(explode(',', $conf['disableactions']), array('register')));
+                    $ok &= io_saveFile($animaldir . '/conf/local.php', "\n" . '$conf[\'disableactions\'] = \''.$disableactions.'\';' . "\n", true);
+                    break;
+                case 'inherit':
+                case true:
+                    // nothing needs to be done
+                    break;
+                default:
+                    $ok &= io_saveFile($animaldir . '/conf/local.php', "\n" . '$conf[\'disableactions\'] = \'register\';' . "\n", true);
+            }
         }
 
         // deactivate plugins by default FIXME this should be nicer

--- a/admin/new.php
+++ b/admin/new.php
@@ -65,7 +65,7 @@ class admin_plugin_farmer_new extends DokuWiki_Admin_Plugin {
         $animals = $this->helper->getAllAnimals();
         array_unshift($animals, '');
         $form->addFieldsetOpen($this->getLang('animal template'));
-        $form->addDropdown('animaltemplate', $animals)->addClass('farmer_choosen_animals');
+        $form->addDropdown('animaltemplate', $animals)->addClass('farmer_chosen_animals');
         $form->addFieldsetClose();
 
         $form->addFieldsetOpen($lang['i_policy'])->attr('id', 'aclPolicyFieldset');

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -75,6 +75,9 @@ $lang['animal template'] = 'Copy existing Animal';
 $lang['animal creation success'] = 'The Animal "%s" has been successfully created.';
 $lang['animal creation error'] = 'There was an error while creating the Animal.';
 $lang['animal configuration'] = 'Basic Animal configuration';
+$lang['inherit user registration'] = 'Inherit user registration setting from farmer';
+$lang['enable user registration'] = 'Allow users to register themselves';
+$lang['disable user registration'] = 'Disable user register';
 $lang['animal administrator'] = 'Animal administrator';
 $lang['noUsers'] = 'Do not create any users';
 $lang['importUsers'] = 'Import all users of the Farmer to the new Animal';
@@ -86,6 +89,7 @@ $lang['animalname_invalid'] = 'The Animal name may only contain alphanumeric cha
 $lang['animalname_preexisting'] = 'An Animal with that name already exists.';
 $lang['adminPassword_empty'] = 'The password for the new admin account must not be empty.';
 $lang['animal template copy error'] = 'There was a problem copying %s from the existing Animal to the new one.';
+$lang['aclpolicy missing/bad'] = 'Please choose an initial ACL policy from the dropdown.';
 
 // plugins
 $lang['bulkSingleSwitcher'] = 'Edit a single Animal or all at once?';

--- a/script/plugins.js
+++ b/script/plugins.js
@@ -10,7 +10,7 @@
 
     jQuery(function () {
         // general animal select
-        var $animalSelect = jQuery('select.farmer_choosen_animals');
+        var $animalSelect = jQuery('select.farmer_chosen_animals');
         $animalSelect.chosen({
             width: '100%',
             search_contains: true,

--- a/script/plugins.js
+++ b/script/plugins.js
@@ -10,11 +10,17 @@
 
     jQuery(function () {
         // general animal select
-        jQuery('select.farmer_choosen_animals').chosen({
+        var $animalSelect = jQuery('select.farmer_choosen_animals');
+        $animalSelect.chosen({
             width: '100%',
             search_contains: true,
             allow_single_deselect: true,
             "placeholder_text_single": LANG.plugins.farmer.animalSelect
+        });
+
+        jQuery('select.acl_chosen').chosen({
+            disable_search: true,
+            width: '100%'
         });
 
 
@@ -59,7 +65,7 @@
 
 
         // make sure there's enough space for the dropdown
-        jQuery('select').on('chosen:showing_dropdown', function (evt, params) {
+        $animalSelect.on('chosen:showing_dropdown', function (evt, params) {
             jQuery(evt.target).parent('fieldset').animate({
                 "padding-bottom": '20em'
             }, 400);
@@ -68,6 +74,18 @@
                 "padding-bottom": '7px'
             }, 400);
         });
+
+        var $aclPolicyFieldset = jQuery('#aclPolicyFieldset');
+        if ($aclPolicyFieldset.length) {
+            $animalSelect.on('change', function (evt, params) {
+                var $this = jQuery(this);
+                if ($this.val() == '') {
+                    $aclPolicyFieldset.slideDown();
+                } else {
+                    $aclPolicyFieldset.slideUp();
+                }
+            });
+        }
 
 
         jQuery("input[name=bulkSingleSwitch]:radio").change(function () {


### PR DESCRIPTION
When creating a new animal and not using an existing one as template, then let the user choose the initial ACL scheme for the new animal. Also let the user choose if new users are allowed to register themselves or not.

closes #24