### PR TITLE
Fix run php-cli on animals with the hostbased configuration

### DIFF
--- a/DokuWikiFarmCore.php
+++ b/DokuWikiFarmCore.php
@@ -116,7 +116,7 @@ class DokuWikiFarmCore {
      * @return string
      */
     public function getAnimalBaseDir() {
-        if($this->isHostbased()) return '';
+        if($this->isHostbased()) return '/';
         return getBaseURL() . '!' . $this->getAnimal();
     }
 


### PR DESCRIPTION
quite unusual use case but maybe it'll be useful for you too.

I run the following script by php-cli:

```
<?php

//include base config
$inc = realpath(__DIR__.'/../../..');
define('DOKU_INC', $inc.'/');

// load and initialize the core system
require_once(DOKU_INC.'inc/init.php');

//...
```

The script requires the dokuwiki DOKU_URL to be set properly but getBaseURL function in inc/init.php leads to bad results when $conf['baseurl'] isn't set:

```
function getBaseURL($abs=null){
    global $conf;
    //if canonical url enabled always return absolute
    if(is_null($abs)) $abs = $conf['canonical'];

    if(!empty($conf['basedir'])){
        $dir = $conf['basedir'];
    }elseif(substr($_SERVER['SCRIPT_NAME'],-4) == '.php'){
        $dir = dirname($_SERVER['SCRIPT_NAME']); // <- this is wrong when run on command line
    }
```

This commits fixes that behaviour for host based animal setup.