### PR TITLE
Allow to set animals as URL on the command line

### DIFF
--- a/DokuWikiFarmCore.php
+++ b/DokuWikiFarmCore.php
@@ -1,6 +1,7 @@
 <?php
 
 // phpcs:disable PSR1.Files.SideEffects
+
 /**
  * Core Manager for the Farm functionality
  *
@@ -131,68 +132,196 @@ class DokuWikiFarmCore
     }
 
     /**
+     * Set the animal
+     *
+     * Checks if the animal exists and is a valid directory name.
+     *
+     * @param mixed $animal the animal name
+     * @return bool returns true if the animal was set successfully, false otherwise
+     */
+    protected function setAnimal($animal)
+    {
+        $farmdir = $this->config['base']['farmdir'];
+
+        // invalid animal stuff is always a not found
+        if (!is_string($animal) || strpbrk($animal, '\\/') !== false) {
+            $this->notfound = true;
+            return false;
+        }
+        $animal = strtolower($animal);
+
+        // check if animal exists
+        if (is_dir("$farmdir/$animal/conf")) {
+            $this->animal = $animal;
+            $this->notfound = false;
+            return true;
+        } else {
+            $this->notfound = true;
+            return false;
+        }
+    }
+
+    /**
+     * Detect the animal from the given query string
+     *
+     * This removes the animal parameter from the given string and sets the animal
+     *
+     * @param string $queryString The query string to extract the animal from, will be modified
+     * @return bool true if the animal was set successfully, false otherwise
+     */
+    protected function detectAnimalFromQueryString(string &$queryString): bool
+    {
+        $params = [];
+        parse_str($queryString, $params);
+        if (!isset($params['animal'])) return false;
+        $animal = $params['animal'];
+        unset($params['animal']);
+        $queryString = http_build_query($params);
+
+        $this->hostbased = false;
+        return $this->setAnimal($animal);
+    }
+
+    /**
+     * Detect the animal from the bang path
+     *
+     * This is used to detect the animal from a bang path like `/!animal/my:page` or '/dokuwiki/!animal/my:page'.
+     *
+     * @param string $path The bang path to extract the animal from
+     * @return bool true if the animal was set successfully, false otherwise
+     */
+    protected function detectAnimalFromBangPath(string $path): bool
+    {
+        $bangregex = '#^(/(?:[^/]*/)*)!([^/]+)/#';
+        if (preg_match($bangregex, $path, $matches)) {
+            // found a bang path
+            $animal = $matches[2];
+
+            $this->hostbased = false;
+            return $this->setAnimal($animal);
+        }
+        return false;
+    }
+
+    /**
+     * Detect the animal from the host name
+     *
+     * @param string $host The hostname
+     * @return bool true if the animal was set successfully, false otherwise
+     */
+    protected function detectAnimalFromHostName(string $host): bool
+    {
+        $possible = $this->getAnimalNamesForHost($host);
+        foreach ($possible as $animal) {
+            if ($this->setAnimal($animal)) {
+                $this->hostbased = true;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Detect the current animal
      *
      * Sets internal members $animal, $notfound and $hostbased
      *
      * This borrows form DokuWiki's inc/farm.php but does not support a default conf dir
+     *
+     * @params string|null $sapi the SAPI to use. Only changed during testing
      */
-    protected function detectAnimal()
+    protected function detectAnimal($sapi = null)
     {
+        $sapi = $sapi ?: PHP_SAPI;
+
         $farmdir = $this->config['base']['farmdir'];
         $farmhost = $this->config['base']['farmhost'];
 
-        // check if animal was set via rewrite parameter
-        $animal = '';
-        if (isset($_GET['animal'])) {
-            $animal = $_GET['animal'];
-            // now unset the parameter to not leak into new queries
-            unset($_GET['animal']);
-            $params = [];
-            parse_str($_SERVER['QUERY_STRING'], $params);
-            if (isset($params['animal'])) unset($params['animal']);
-            $_SERVER['QUERY_STRING'] = http_build_query($params);
-        }
-        // get animal from CLI parameter
-        if ('cli' == PHP_SAPI && isset($_SERVER['animal'])) $animal = $_SERVER['animal'];
-        if ($animal) {
-            // check that $animal is a string and just a directory name and not a path
-            if (!is_string($animal) || strpbrk($animal, '\\/') !== false) {
-                $this->notfound = true;
-                return;
-            };
-            $animal = strtolower($animal);
+        if ('cli' == $sapi) {
+            if (!isset($_SERVER['animal'])) return; // no animal parameter given - we're the farmer
 
-            // check if animal exists
-            if (is_dir("$farmdir/$animal/conf")) {
-                $this->animal = $animal;
-                return;
+            if (preg_match('#^https?://#i', $_SERVER['animal'])) {
+                // CLI animal parameter is a URL
+                $urlparts = parse_url($_SERVER['animal']);
+                $urlparts['query'] ??= '';
+
+                // detect the animal from the URL
+                $this->detectAnimalFromQueryString($urlparts['query']) ||
+                $this->detectAnimalFromBangPath($urlparts['path']) ||
+                $this->detectAnimalFromHostName($urlparts['host']);
+
+                // fake baseurl etc.
+                $this->injectServerEnvironment($urlparts);
             } else {
+                // CLI animal parameter is just a name
+                $this->setAnimal(strtolower($_SERVER['animal']));
+            }
+
+        } else {
+            // an animal url parameter has been set
+            if (isset($_GET['animal'])) {
+                $this->detectAnimalFromQueryString($_SERVER['QUERY_STRING']);
+                unset($_GET['animal']);
+                return;
+            }
+
+            // no host - no host based setup. if we're still here then it's the farmer
+            if (empty($_SERVER['HTTP_HOST'])) return;
+
+            // is this the farmer?
+            if (strtolower($_SERVER['HTTP_HOST']) == $farmhost) {
+                return;
+            }
+
+            // we're in host based mode now
+            $this->hostbased = true;
+
+            // we should get an animal now
+            if (!$this->detectAnimalFromHostName($_SERVER['HTTP_HOST'])) {
                 $this->notfound = true;
-                return;
             }
         }
+    }
 
-        // no host - no host based setup. if we're still here then it's the farmer
-        if (!isset($_SERVER['HTTP_HOST'])) return;
+    /**
+     * Create Server environment variables for the current animal
+     *
+     * This is called when the animal is initialized on the command line using a full URL.
+     * Since the initialization is running before any configuration is loaded, we instead
+     * set the $_SERVER variables that will later be used to autodetect the base URL. This
+     * way a manually set base URL will still take precedence.
+     *
+     * @param array $urlparts A parse_url() result array
+     * @return void
+     * @see is_ssl()
+     * @see getBaseURL()
+     */
+    protected function injectServerEnvironment(array $urlparts)
+    {
+        // prepare data for DOKU_REL
+        $path = $urlparts['path'] ?? '/';
+        if (($bangpos = strpos($path, '!')) !== false) {
+            // strip from the bang path
+            $path = substr($path, 0, $bangpos);
+        }
+        if (!str_ends_with($path, '.php')) {
+            // make sure we have a script name
+            $path = rtrim($path, '/') . '/doku.php';
+        }
+        $_SERVER['SCRIPT_NAME'] = $path;
 
-        // is this the farmer?
-        if (strtolower($_SERVER['HTTP_HOST']) == $farmhost) {
-            return;
+        // prepare data for is_ssl()
+        if (($urlparts['scheme'] ?? '') === 'https') {
+            $_SERVER['HTTPS'] = 'on';
+        } else {
+            $_SERVER['HTTPS'] = 'off';
         }
 
-        // still here? check for host based
-        $this->hostbased = true;
-        $possible = $this->getAnimalNamesForHost($_SERVER['HTTP_HOST']);
-        foreach ($possible as $animal) {
-            if (is_dir("$farmdir/$animal/conf/")) {
-                $this->animal = $animal;
-                return;
-            }
+        // prepare data for DOKU_URL
+        $_SERVER['HTTP_HOST'] = $urlparts['host'] ?? '';
+        if (isset($urlparts['port'])) {
+            $_SERVER['HTTP_HOST'] .= ':' . $urlparts['port'];
         }
-
-        // no hit
-        $this->notfound = true;
     }
 
     /**
@@ -338,7 +467,7 @@ class DokuWikiFarmCore
             $prepend = [];
             if ($key == 'main') {
                 $prepend = [
-                     'protected' => [DOKU_INC . 'conf/local.protected.php']
+                    'protected' => [DOKU_INC . 'conf/local.protected.php']
                 ];
                 $append = [
                     'default' => [DOKU_INC . 'conf/local.php'],

--- a/_test/core.test.php
+++ b/_test/core.test.php
@@ -13,10 +13,46 @@ class DokuWikiFarmCore extends \DokuWikiFarmCore
         // we do not intitialize anyting else here because it's already too late and DOKU_INC is already set
     }
 
-
     public function getAnimalNamesForHost($host)
     {
         return parent::getAnimalNamesForHost($host);
+    }
+
+    public function detectAnimal($sapi = null)
+    {
+        parent::detectAnimal($sapi);
+    }
+
+    public function setConfig($config)
+    {
+        $this->config = $config;
+    }
+
+    public function getAnimal()
+    {
+        return $this->animal;
+    }
+
+    public function wasNotfound()
+    {
+        return $this->notfound;
+    }
+
+    public function isHostbased()
+    {
+        return $this->hostbased;
+    }
+
+    public function resetState()
+    {
+        $this->animal = false;
+        $this->notfound = false;
+        $this->hostbased = false;
+    }
+
+    public function injectServerEnvironment(array $urlparts)
+    {
+        parent::injectServerEnvironment($urlparts);
     }
 }
 
@@ -31,6 +67,9 @@ class core_plugin_farmer_test extends \DokuWikiTest
     protected $pluginsEnabled = ['farmer'];
 
 
+    /**
+     * Test the getAnimalNamesForHost method
+     */
     public function test_hostsAnimals()
     {
         $core = new DokuWikiFarmCore();
@@ -49,5 +88,267 @@ class core_plugin_farmer_test extends \DokuWikiTest
         ];
 
         $this->assertEquals($expect, $core->getAnimalNamesForHost($input));
+    }
+
+    /**
+     * Data provider for detectAnimal tests
+     */
+    public function detectAnimalProvider()
+    {
+        return [
+            'animal via GET parameter - exists' => [
+                'get_params' => ['animal' => 'testanimal'],
+                'server_params' => [],
+                'sapi' => 'apache2handler',
+                'expected_animal' => 'testanimal',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/testanimal/conf'],
+            ],
+            'animal via GET parameter - not found' => [
+                'get_params' => ['animal' => 'nonexistent'],
+                'server_params' => [],
+                'sapi' => 'apache2handler',
+                'expected_animal' => false,
+                'expected_notfound' => true,
+                'expected_hostbased' => false,
+            ],
+            'animal via GET parameter - invalid path' => [
+                'get_params' => ['animal' => '../badpath'],
+                'server_params' => [],
+                'sapi' => 'apache2handler',
+                'expected_animal' => false,
+                'expected_notfound' => true,
+                'expected_hostbased' => false,
+            ],
+            'farmer host' => [
+                'get_params' => [],
+                'server_params' => ['HTTP_HOST' => 'farm.example.com'],
+                'sapi' => 'apache2handler',
+                'expected_animal' => false,
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+            ],
+            'host-based animal - exists' => [
+                'get_params' => [],
+                'server_params' => ['HTTP_HOST' => 'sub.example.com'],
+                'sapi' => 'apache2handler',
+                'expected_animal' => 'sub.example.com',
+                'expected_notfound' => false,
+                'expected_hostbased' => true,
+                'create_dirs' => ['/tmp/farm/sub.example.com/conf'],
+            ],
+            'host-based animal - not found' => [
+                'get_params' => [],
+                'server_params' => ['HTTP_HOST' => 'unknown.example.com'],
+                'sapi' => 'apache2handler',
+                'expected_animal' => false,
+                'expected_notfound' => true,
+                'expected_hostbased' => true,
+            ],
+            'CLI animal parameter - name only' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'clianimal'],
+                'sapi' => 'cli',
+                'expected_animal' => 'clianimal',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/clianimal/conf'],
+            ],
+            'CLI animal parameter - URL with query' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'https://example.com/path?animal=urlanimal&other=param'],
+                'sapi' => 'cli',
+                'expected_animal' => 'urlanimal',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/urlanimal/conf'],
+            ],
+            'CLI animal parameter - URL with bang path' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'https://example.com/!banganimal/page'],
+                'sapi' => 'cli',
+                'expected_animal' => 'banganimal',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/banganimal/conf'],
+            ],
+            'CLI animal parameter - URL with bang path in subdir' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'https://example.com/dokuwiki/!banganimal/page'],
+                'sapi' => 'cli',
+                'expected_animal' => 'banganimal',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/banganimal/conf'],
+            ],
+            'CLI animal parameter - URL with hostname' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'https://hostanimal.example.com/page'],
+                'sapi' => 'cli',
+                'expected_animal' => 'hostanimal.example.com',
+                'expected_notfound' => false,
+                'expected_hostbased' => true,
+                'create_dirs' => ['/tmp/farm/hostanimal.example.com/conf'],
+            ],
+            'CLI no animal parameter' => [
+                'get_params' => [],
+                'server_params' => [],
+                'sapi' => 'cli',
+                'expected_animal' => false,
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+            ],
+            'CLI animal parameter - URL with bang and query' => [
+                'get_params' => [],
+                'server_params' => ['animal' => 'https://example.com/!bangquery/page?param=value'],
+                'sapi' => 'cli',
+                'expected_animal' => 'bangquery',
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+                'create_dirs' => ['/tmp/farm/bangquery/conf'],
+            ],
+            'HTTP no host header' => [
+                'get_params' => [],
+                'server_params' => ['HTTP_HOST' => ''], // our test environment sets one
+                'sapi' => 'apache2handler',
+                'expected_animal' => false,
+                'expected_notfound' => false,
+                'expected_hostbased' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider detectAnimalProvider
+     * @param array $get_params GET parameters to set in $_GET
+     * @param array $server_params SERVER parameters to set in $_SERVER
+     * @param string $sapi SAPI to simulate
+     * @param string|false $expected_animal Expected animal name or false
+     * @param bool $expected_notfound Expected notfound state
+     * @param bool $expected_hostbased Expected hostbased state
+     * @param array $create_dirs Directories to create for the test
+     */
+    public function test_detectAnimal($get_params, $server_params, $sapi, $expected_animal, $expected_notfound, $expected_hostbased, $create_dirs = [])
+    {
+        // Create temporary directories if needed
+        foreach ($create_dirs as $dir) {
+            if (!is_dir($dir)) {
+                mkdir($dir, 0755, true);
+            }
+        }
+
+        // Backup original values
+        $original_get = $_GET;
+        $original_server = $_SERVER;
+        $original_query_string = $_SERVER['QUERY_STRING'] ?? '';
+
+        try {
+            // Set up test environment
+            $_GET = array_merge($_GET, $get_params);
+            $_SERVER = array_merge($_SERVER, $server_params);
+            if (!empty($get_params)) {
+                $_SERVER['QUERY_STRING'] = http_build_query($get_params);
+            }
+
+            $config = ['base' => ['farmdir' => '/tmp/farm', 'farmhost' => 'farm.example.com']];
+            $core = new DokuWikiFarmCore();
+            $core->setConfig($config);
+            $core->resetState();
+            $core->detectAnimal($sapi);
+
+            $this->assertEquals($expected_animal, $core->getAnimal(), 'Animal detection failed');
+            $this->assertEquals($expected_notfound, $core->wasNotfound(), 'Notfound state incorrect');
+            $this->assertEquals($expected_hostbased, $core->isHostbased(), 'Hostbased state incorrect');
+
+        } finally {
+            // Restore original values
+            $_GET = $original_get;
+            $_SERVER = $original_server;
+            $_SERVER['QUERY_STRING'] = $original_query_string;
+
+            // Clean up created directories
+            foreach ($create_dirs as $dir) {
+                if (is_dir($dir)) {
+                    rmdir($dir);
+                    // Also remove parent directories if they're empty
+                    $parent = dirname($dir);
+                    while ($parent !== '/' && $parent !== '.' && is_dir($parent) && count(scandir($parent)) === 2) {
+                        rmdir($parent);
+                        $parent = dirname($parent);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Data provider for injectServerEnvironment tests
+     */
+    public function injectServerEnvironmentProvider()
+    {
+        return [
+            'HTTPS URL with port' => [
+                'url' => 'https://example.com:8443/dokuwiki/doku.php',
+                'expected_baseurl' => 'https://example.com:8443',
+                'expected_basedir' => '/dokuwiki/',
+            ],
+            'HTTP URL with default port' => [
+                'url' => 'http://test.example.com/doku.php',
+                'expected_baseurl' => 'http://test.example.com',
+                'expected_basedir' => '/',
+            ],
+            'HTTPS URL with bang path' => [
+                'url' => 'https://farm.example.com/!animal/doku.php',
+                'expected_baseurl' => 'https://farm.example.com',
+                'expected_basedir' => '/',
+            ],
+            'HTTP URL with subdirectory and bang path' => [
+                'url' => 'http://wiki.example.com/dokuwiki/!testanimal/start',
+                'expected_baseurl' => 'http://wiki.example.com',
+                'expected_basedir' => '/dokuwiki/',
+            ],
+            'HTTPS URL with custom port and path' => [
+                'url' => 'https://secure.example.com:9443/wiki',
+                'expected_baseurl' => 'https://secure.example.com:9443',
+                'expected_basedir' => '/wiki/',
+            ],
+            'HTTP URL with root path' => [
+                'url' => 'http://simple.example.com/',
+                'expected_baseurl' => 'http://simple.example.com',
+                'expected_basedir' => '/',
+            ],
+            'HTTP URL with no path' => [
+                'url' => 'http://simple.example.com',
+                'expected_baseurl' => 'http://simple.example.com',
+                'expected_basedir' => '/',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider injectServerEnvironmentProvider
+     * @param string $url The URL to parse and inject
+     * @param string $expected_baseurl Expected base URL after injection
+     * @param string $expected_basedir Expected base directory after injection
+     */
+    public function test_injectServerEnvironment($url, $expected_baseurl, $expected_basedir)
+    {
+        // Clear relevant server variables
+        unset($_SERVER['HTTPS'], $_SERVER['HTTP_HOST'], $_SERVER['SCRIPT_NAME']);
+
+        $core = new DokuWikiFarmCore();
+        $urlparts = parse_url($url);
+        $core->injectServerEnvironment($urlparts);
+
+        $base_dir = getBaseURL(false);
+        $base_url = getBaseURL(true);
+
+        // first check that the directory was detected correctly…
+        $this->assertEquals($expected_basedir, $base_dir, 'Base directory does not match expected value');
+        // …then check that the expected base URL plus the directory matches the absolute URL
+        $this->assertEquals($expected_baseurl . $base_dir, $base_url, 'Absolute URL does not match expected value');
+
+
     }
 }


### PR DESCRIPTION
The URL is parsed for selecting the right animal and it is used to initialize the environment so that getBaseURL() will return the proper value. This should fix #87 